### PR TITLE
Allow optional EXPORT_TOKEN for exporter

### DIFF
--- a/.github/workflows/export-project-items.yml
+++ b/.github/workflows/export-project-items.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python tools/export_project_items.py --project-id PVT_kwHODCzAMM4BDOn_ --out-dir planning
+          python tools/export_project_items.py --project-id PVT_kwHODCzAMM4BDOn_ --out-dir planning --token "${{ secrets.EXPORT_TOKEN }}"
       - name: Upload snapshots as artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Pass optional secret EXPORT_TOKEN into exporter so workflows can use a PAT when necessary.