### PR TITLE
CI: Align ci.yml triggers to run on PRs to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ dashboard ]
+    branches: [ master, dashboard ]
 
 jobs:
   test:


### PR DESCRIPTION
This PR updates .github/workflows/ci.yml so it triggers on pull requests to master (in addition to dashboard), reducing confusion about why it sometimes doesn't run.

- before: ci.yml ran only on PRs to `dashboard`
- after: runs on PRs to `master` and `dashboard`

No behavior change to existing minimal workflows (Artifacts, Playwright server smoke). This is just to keep expectations clear and make CI visibility consistent across PRs.